### PR TITLE
Add WasmJs target

### DIFF
--- a/gradle/conventionLibs.versions.toml
+++ b/gradle/conventionLibs.versions.toml
@@ -5,10 +5,10 @@
 # dependencies like test libraries.
 
 [versions]
-coroutines = "1.7.3"
-serialization = "1.5.1"
+coroutines = "1.8.0-RC2"
+serialization = "1.6.2"
 datetime = "0.4.0"
-ktor = "2.3.3"
+ktor = "3.0.0-wasm2"
 
 androidxLifecycle = "2.6.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@
 [libraries]
 
 gradlePlugin-android                      = { module = "com.android.tools.build:gradle", version = "8.1.0" }
-gradlePlugin-kotlin                       = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.9.0" }
+gradlePlugin-kotlin                       = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "1.9.22" }
 gradlePlugin-kotlinSerialization          = { module = "org.jetbrains.kotlin:kotlin-serialization", version = "1.9.0" }
-gradlePlugin-kotlinCompose                = { module = "org.jetbrains.compose:compose-gradle-plugin", version = "1.4.3" }
+gradlePlugin-kotlinCompose                = { module = "org.jetbrains.compose:compose-gradle-plugin", version = "1.6.0-beta01" }
 gradlePlugin-ktlint                       = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "11.5.1" }
 gradlePlugin-kotest                       = { module = "io.kotest:kotest-framework-multiplatform-plugin-gradle", version = "5.6.2" }
 gradlePlugin-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version = "0.13.2" }

--- a/src/main/kotlin/com/copperleaf/gradle/SubprojectInfo.kt
+++ b/src/main/kotlin/com/copperleaf/gradle/SubprojectInfo.kt
@@ -12,6 +12,7 @@ data class SubprojectInfo(
     val kotlinIos: Boolean,
     val kotlinJs: Boolean,
     val kotlinJsExecutable: Boolean,
+    val kotlinWasmJs: Boolean,
 
     val composeMaterial2: Boolean,
     val composeSplitPane: Boolean,
@@ -31,6 +32,7 @@ data class SubprojectInfo(
                 kotlinIos = conventionProperties.booleanGradleProperty("copperleaf.targets.ios"),
                 kotlinJs = conventionProperties.booleanGradleProperty("copperleaf.targets.js"),
                 kotlinJsExecutable = conventionProperties.booleanGradleProperty("copperleaf.targets.js.executable"),
+                kotlinWasmJs = conventionProperties.booleanGradleProperty("copperleaf.targets.wasmJs"),
 
                 composeMaterial2 = conventionProperties.booleanGradleProperty("copperleaf.compose.material2", defaultValue = true),
                 composeSplitPane = conventionProperties.booleanGradleProperty("copperleaf.compose.splitPane"),

--- a/src/main/kotlin/copper-leaf-kotest.gradle.kts
+++ b/src/main/kotlin/copper-leaf-kotest.gradle.kts
@@ -15,10 +15,10 @@ kotlin {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0-RC2")
 
-                implementation("io.kotest:kotest-framework-engine:5.6.2")
-                implementation("io.kotest:kotest-assertions-core:5.6.2")
-                implementation("io.kotest:kotest-framework-datatest:5.6.2")
-                implementation("io.kotest:kotest-property:5.6.2")
+//                implementation("io.kotest:kotest-framework-engine:5.6.2")
+//                implementation("io.kotest:kotest-assertions-core:5.6.2")
+//                implementation("io.kotest:kotest-framework-datatest:5.6.2")
+//                implementation("io.kotest:kotest-property:5.6.2")
             }
         }
 
@@ -27,7 +27,7 @@ kotlin {
                 dependencies {
                     implementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
                     runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
-                    implementation("io.kotest:kotest-runner-junit5:5.6.2")
+//                    implementation("io.kotest:kotest-runner-junit5:5.6.2")
                 }
             }
         }
@@ -37,7 +37,7 @@ kotlin {
                 dependencies {
                     implementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
                     runtimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.2")
-                    implementation("io.kotest:kotest-runner-junit5:5.6.2")
+//                    implementation("io.kotest:kotest-runner-junit5:5.6.2")
                 }
             }
         }

--- a/src/main/kotlin/copper-leaf-kotest.gradle.kts
+++ b/src/main/kotlin/copper-leaf-kotest.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     sourceSets {
         val commonTest by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0-RC2")
 
                 implementation("io.kotest:kotest-framework-engine:5.6.2")
                 implementation("io.kotest:kotest-assertions-core:5.6.2")

--- a/src/main/kotlin/copper-leaf-targets.gradle.kts
+++ b/src/main/kotlin/copper-leaf-targets.gradle.kts
@@ -2,6 +2,7 @@
 
 import com.copperleaf.gradle.ConventionConfig
 import com.copperleaf.gradle.nativeTargetGroup
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")
@@ -36,6 +37,12 @@ kotlin {
             if(subprojectInfo.kotlinJsExecutable) {
                 binaries.executable()
             }
+        }
+    }
+    if (subprojectInfo.kotlinWasmJs) {
+        @OptIn(ExperimentalWasmDsl::class)
+        wasmJs {
+            binaries.executable()
         }
     }
     if (subprojectInfo.kotlinIos) {
@@ -84,6 +91,15 @@ kotlin {
                 dependencies { }
             }
             val jsTest by getting {
+                dependencies { }
+            }
+        }
+
+        if (subprojectInfo.kotlinWasmJs) {
+            val wasmJsMain by getting {
+                dependencies { }
+            }
+            val wasmJsTest by getting {
                 dependencies { }
             }
         }


### PR DESCRIPTION
Hi. As you can see in the [2nd commit](https://github.com/copper-leaf/gradle-convention-plugins/pull/1/commits/d01c5cc174b1f0e0f3bd36b2f7fa77e7917865b3), the Kotest lack of WasmJs support is blocking us from enabling it in this repo.

The Kotest seems to have existing [PR](https://github.com/kotest/kotest/pull/3805) for adding Wasm created before Christmas 🤞 it won't take long.